### PR TITLE
Fix `types` usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "license": "MIT",
   "files": ["*.d.ts"],
   "main": "shim.d.ts",
+  "types": "shim.d.ts",
   "sideEffects": false,
   "scripts": {
     "test": "tsc -p ."


### PR DESCRIPTION
If you try to use the package with the `types` field in `tsconfig.json` you will get a `Cannot find type definition file for 'typed-query-selector'.` error.

This is because the `types` field in `package.json` is missing, so TS doesn't know where to look for them.