### PR TITLE
Add :not(), :last-child, and spaced attribute value tests

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -44,9 +44,9 @@ type _Tests = [
   Expect<
     Equal<ParseSelector<'link[type="application/atom+xml"]'>, HTMLLinkElement>
   >,
-  Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>
   Expect<Equal<ParseSelector<'input[aria-label="Full name"]'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'input:not([type=email])'>, HTMLInputElement>>,
+  Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>
 ]
 
 const el: HTMLDivElement | HTMLSpanElement | null = document.querySelector(

--- a/test.ts
+++ b/test.ts
@@ -45,6 +45,7 @@ type _Tests = [
     Equal<ParseSelector<'link[type="application/atom+xml"]'>, HTMLLinkElement>
   >,
   Expect<Equal<ParseSelector<'input[aria-label="Full name"]'>, HTMLInputElement>>,
+  Expect<Equal<ParseSelector<'input:last-child'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'input:not([type=email])'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>
 ]

--- a/test.ts
+++ b/test.ts
@@ -45,6 +45,8 @@ type _Tests = [
     Equal<ParseSelector<'link[type="application/atom+xml"]'>, HTMLLinkElement>
   >,
   Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>
+  Expect<Equal<ParseSelector<'input[aria-label="Full name"]'>, HTMLInputElement>>,
+  Expect<Equal<ParseSelector<'input:not([type=email])'>, HTMLInputElement>>,
 ]
 
 const el: HTMLDivElement | HTMLSpanElement | null = document.querySelector(


### PR DESCRIPTION
`:not()` doesn't appear to be currently supported. Maybe spaced attributes are supported in the latest version.