### PR TITLE
Add test for attribute values containing `[]`

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -59,6 +59,7 @@ type _Tests = [
   >,
   Expect<Equal<ParseSelector<'input:last-child'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'input:not([type=email])'>, HTMLInputElement>>,
+  Expect<Equal<ParseSelector<'textarea[name="comment[body]"]'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>
 ]
 

--- a/test.ts
+++ b/test.ts
@@ -59,7 +59,7 @@ type _Tests = [
   >,
   Expect<Equal<ParseSelector<'input:last-child'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'input:not([type=email])'>, HTMLInputElement>>,
-  Expect<Equal<ParseSelector<'textarea[name="comment[body]"]'>, HTMLInputElement>>,
+  Expect<Equal<ParseSelector<'textarea[name="comment[body]"]'>, HTMLTextAreaElement>>,
   Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>
 ]
 

--- a/test.ts
+++ b/test.ts
@@ -24,6 +24,15 @@ type _Tests = [
       HTMLHeadingElement
     >
   >,
+  Expect<
+    Equal<
+      ParseSelector<`
+    input,
+    button
+  `>,
+      HTMLInputElement | HTMLButtonElement
+    >
+  >,
   Expect<Equal<ParseSelector<'div, span'>, HTMLDivElement | HTMLSpanElement>>,
   Expect<Equal<ParseSelector<'span.text-center'>, HTMLSpanElement>>,
   Expect<Equal<ParseSelector<'button#submit'>, HTMLButtonElement>>,

--- a/test.ts
+++ b/test.ts
@@ -24,15 +24,6 @@ type _Tests = [
       HTMLHeadingElement
     >
   >,
-  Expect<
-    Equal<
-      ParseSelector<`
-    input,
-    button
-  `>,
-      HTMLInputElement | HTMLButtonElement
-    >
-  >,
   Expect<Equal<ParseSelector<'div, span'>, HTMLDivElement | HTMLSpanElement>>,
   Expect<Equal<ParseSelector<'span.text-center'>, HTMLSpanElement>>,
   Expect<Equal<ParseSelector<'button#submit'>, HTMLButtonElement>>,


### PR DESCRIPTION
Brackets are common in `name` attributes: https://mattstauffer.com/blog/a-little-trick-for-grouping-fields-in-an-html-form/

More tests may come as I verify my code