### PR TITLE
Allow specifying a different fallback type

### DIFF
--- a/parser.d.ts
+++ b/parser.d.ts
@@ -45,7 +45,7 @@ type Postprocess<I> = I extends `${infer Tag}.${string}`
   ? Postprocess<Tag>
   : I
 
-export type ParseSelector<I extends string, Fallback extends Element> = string extends I
+export type ParseSelector<I extends string, Fallback extends Element = Element> = string extends I
   ? Fallback
   : Preprocess<I> extends infer I
   ? I extends `${string}${Combinators}${infer Right}`

--- a/parser.d.ts
+++ b/parser.d.ts
@@ -45,8 +45,8 @@ type Postprocess<I> = I extends `${infer Tag}.${string}`
   ? Postprocess<Tag>
   : I
 
-export type ParseSelector<I extends string> = string extends I
-  ? Element
+export type ParseSelector<I extends string, Fallback extends Element> = string extends I
+  ? Fallback
   : Preprocess<I> extends infer I
   ? I extends `${string}${Combinators}${infer Right}`
     ? ParseSelector<Right>
@@ -56,7 +56,7 @@ export type ParseSelector<I extends string> = string extends I
         ? HTMLElementTagNameMap[Tags]
         : Tags extends keyof SVGElementTagNameMap
         ? SVGElementTagNameMap[Tags]
-        : Element
+        : Fallback
       : never
     : never
   : never

--- a/test.ts
+++ b/test.ts
@@ -60,7 +60,7 @@ type _Tests = [
   Expect<Equal<ParseSelector<'input:last-child'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'input:not([type=email])'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>,
-  Expect<Equal<ParseSelector<'.button', HTMLButtonElement>, HTMLButtonElement>> // Allow customization of default
+  Expect<Equal<ParseSelector<'.button', HTMLButtonElement>, HTMLButtonElement>>, // Allow customization of default
   Expect<Equal<ParseSelector<'input.button', HTMLButtonElement>, HTMLInputElement>> // The fallback should never override the parsed type
 ]
 

--- a/test.ts
+++ b/test.ts
@@ -59,7 +59,9 @@ type _Tests = [
   >,
   Expect<Equal<ParseSelector<'input:last-child'>, HTMLInputElement>>,
   Expect<Equal<ParseSelector<'input:not([type=email])'>, HTMLInputElement>>,
-  Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>
+  Expect<Equal<ParseSelector<'div[data-d] button[data-b]'>, HTMLButtonElement>>,
+  Expect<Equal<ParseSelector<'.button', HTMLButtonElement>, HTMLButtonElement>> // Allow customization of default
+  Expect<Equal<ParseSelector<'input.button', HTMLButtonElement>, HTMLInputElement>> // The fallback should never override the parsed type
 ]
 
 const el: HTMLDivElement | HTMLSpanElement | null = document.querySelector(


### PR DESCRIPTION
This should let me suggest an different type in case the tag name can't be found, for example:

```ts
Equal<ParseSelector<'.btn', HTMLElement>, HTMLElement>