### PR TITLE
fix to support typescript 4.5

### DIFF
--- a/parser.d.ts
+++ b/parser.d.ts
@@ -134,7 +134,13 @@ type PostprocessEach<I> = I extends `${infer Tag}.${infer Rest}`
 export type ParseSelectorToTagNames<I extends string> = Trim<I> extends infer I
   ? I extends ''
     ? unknown
-    : Postprocess<Split<ExpandFunctions<Preprocess<PreprocessGrouping<I>>>>>
+    : Split<
+        ExpandFunctions<Preprocess<PreprocessGrouping<I>>>
+      > extends infer PreprocessedTagNames
+    ? PreprocessedTagNames extends string[]
+      ? Postprocess<PreprocessedTagNames>
+      : unknown
+    : never
   : never
 
 export type ParseSelector<


### PR DESCRIPTION
TypeScript 4.5 complains that

```
 Type 'Split<ExpandFunctions<Preprocess<PreprocessGrouping<I>>, "", [], "">>' does not satisfy the constraint 'string[]'
```

at `Postprocess<Split<ExpandFunctions<Preprocess<PreprocessGrouping<I>>>>>`

So now `unknown` needs to be handled before passing any `string[]` to `Postprocess<>`.

There's a few ways to handle this and I just picked one, so I won't feel bad if you close my PR and fix it in a way you feel better fits into the existing code :)