### PR TITLE
Add Fallback support to `StrictlyParseSelector`

### DIFF
--- a/parser.d.ts
+++ b/parser.d.ts
@@ -221,13 +221,16 @@ type IsValidRestChars<S extends string> = S extends `${infer H}${infer Rest}`
     : false
   : true // no characters left, so it's OK
 
-export type StrictlyParseSelector<S extends string> =
+export type StrictlyParseSelector<
+  S extends string,
+  Fallback extends Element = Element,
+> =
   ParseSelectorToTagNames<S> extends infer Tags
     ? Tags extends []
-      ? TagNameToElement<''>
+      ? TagNameToElement<'', Fallback>
       : Tags extends string[]
       ? IsValidTags<Tags> extends true
-        ? TagNameToElement<Tags[number]>
+        ? TagNameToElement<Tags[number], Fallback>
         : never
       : never
     : never


### PR DESCRIPTION
Like https://github.com/g-plane/typed-query-selector/commit/d797f143b2fee950e37d90da2c85b701af723b1e but for `StrictlyParseSelector`

Does this make sense in the strict parser?

Missing:

- [ ] docs (StrictlyParseSelector isn't documented at all)
- [ ] tests