### PR TITLE
Fix extensions (moduleResolution: Node16)

### DIFF
--- a/parser.test.ts
+++ b/parser.test.ts
@@ -1,5 +1,5 @@
-import type { Equal, Expect, NotEqual } from '@type-challenges/utils'
-import type { ParseSelector } from './parser'
+import type { Equal, Expect, NotEqual } from '@type-challenges/utils.js'
+import type { ParseSelector } from './parser.js'
 
 declare class DefinedWebComponent extends HTMLElement {
   #brand

--- a/parser.test.ts
+++ b/parser.test.ts
@@ -1,4 +1,4 @@
-import type { Equal, Expect, NotEqual } from '@type-challenges/utils.js'
+import type { Equal, Expect, NotEqual } from '@type-challenges/utils'
 import type { ParseSelector } from './parser.js'
 
 declare class DefinedWebComponent extends HTMLElement {

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -1,4 +1,4 @@
-import type { ParseSelector } from './parser'
+import type { ParseSelector } from './parser.js'
 
 declare global {
   interface ParentNode {

--- a/shim.test.ts
+++ b/shim.test.ts
@@ -1,5 +1,5 @@
 import './shim.js'
-import type { Equal, Expect } from '@type-challenges/utils.js'
+import type { Equal, Expect } from '@type-challenges/utils'
 
 const htmlEl = document.querySelector(
   '.container > #sign-up-form > div#notice, span.tip',

--- a/shim.test.ts
+++ b/shim.test.ts
@@ -1,5 +1,5 @@
-import './shim'
-import type { Equal, Expect } from '@type-challenges/utils'
+import './shim.js'
+import type { Equal, Expect } from '@type-challenges/utils.js'
 
 const htmlEl = document.querySelector(
   '.container > #sign-up-form > div#notice, span.tip',

--- a/strict.d.ts
+++ b/strict.d.ts
@@ -1,4 +1,4 @@
-import type { StrictlyParseSelector } from './parser'
+import type { StrictlyParseSelector } from './parser.js'
 
 declare global {
   interface ParentNode {

--- a/strict.test.ts
+++ b/strict.test.ts
@@ -1,5 +1,5 @@
 import './strict.js'
-import type { Equal, Expect } from '@type-challenges/utils.js'
+import type { Equal, Expect } from '@type-challenges/utils'
 
 const e1 = document.querySelector('#app')
 const e2 = document.querySelector('.container')

--- a/strict.test.ts
+++ b/strict.test.ts
@@ -1,5 +1,5 @@
-import './strict'
-import type { Equal, Expect } from '@type-challenges/utils'
+import './strict.js'
+import type { Equal, Expect } from '@type-challenges/utils.js'
 
 const e1 = document.querySelector('#app')
 const e2 = document.querySelector('.container')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "skipLibCheck": false,
     "noEmit": true,
-    "noUnusedLocals": false
+    "noUnusedLocals": false,
+    "moduleResolution": "node16"
   }
 }


### PR DESCRIPTION
Extension-less imports are not valid ESM code. Also TypeScript forces us to use .js, never .ts