### PR TITLE
Point to the new TypeScript handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ el.className // TypeScript will report error when compiling
 In runtime, if you pass an invalid selector string to `querySelector` or
 `querySelectorAll` function, it will throw an error instead of returning
 `null` or `undefined` or anything else.
-For details, please read [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html#never).
+For details, please read [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-never-type).
 
 ## 🔗 Related
 


### PR DESCRIPTION
The [current link](https://www.typescriptlang.org/docs/handbook/basic-types.html#never) has a deprecation warning, unlike [the new one](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-never-type).

| Before | After |
|--------|--------|
| <img width="1282" alt="image" src="https://github.com/g-plane/typed-query-selector/assets/76776/2e334965-6129-4af1-94fa-ed7f2520c27a"> | <img width="1205" alt="image" src="https://github.com/g-plane/typed-query-selector/assets/76776/276f56ee-1305-4bc4-a077-b65136d561d6"> | 